### PR TITLE
Add embed fonts feature for typst-kit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ ureq = "2.9"
 # utils
 time = "0.3"
 ttf-parser = "0.25"
-typst-kit = "0.13.1"
+typst-kit = { version = "0.13", features = ["embed-fonts"] }
 
 [lib]
 name = "typst_as_library"


### PR DESCRIPTION
HI, I was using this project and noticed that the fonts weren't embedded in the generated pdf. This was because the `embed-fonts` feature was missing in typst-kit.

`typst-cli` has this feature enabled [here](https://github.com/typst/typst/blob/6177c1b22df6d675646102247eb4382a3f1db60d/crates/typst-cli/Cargo.toml#L69-L82).

By enabling that feature, the generated pdf had all fonts.